### PR TITLE
Ensure mobile layout fits screen width

### DIFF
--- a/no3d-tools-website/styles.css
+++ b/no3d-tools-website/styles.css
@@ -1545,6 +1545,15 @@ body {
     font-size: var(--font-size-micro);
     gap: var(--space-small);
   }
+
+  .search-input {
+    font-size: 16px;
+    line-height: 1.4;
+  }
+
+  .search-input::placeholder {
+    font-size: 16px;
+  }
 }
 
 /* Shopping Cart Modal */

--- a/styles.css
+++ b/styles.css
@@ -1300,6 +1300,15 @@ body {
     font-size: var(--font-size-micro);
     gap: var(--space-small);
   }
+
+  .search-input {
+    font-size: 16px;
+    line-height: 1.4;
+  }
+
+  .search-input::placeholder {
+    font-size: 16px;
+  }
 }
 
 /* Shopping Cart Modal */


### PR DESCRIPTION
Increase mobile search input font size to prevent viewport zooming on iOS.

Safari on iOS automatically zooms the viewport when an input field with a font size less than 16px is focused. Raising the font size to 16px for the mobile search input and its placeholder prevents this unwanted behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-3521d235-728e-496a-95eb-f58b6188ff67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3521d235-728e-496a-95eb-f58b6188ff67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

