### PR TITLE
Hide search input, keep icon functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,11 @@
         <span class="footer-text">RTHEUELLTRROT</span>
     </footer>
 
+    <!-- Search Icon Button - Fixed Bottom Right -->
+    <button class="search-icon-button" id="search-icon-button" aria-label="Search">
+        <i class="fas fa-search"></i>
+    </button>
+
     <!-- Command Palette Search Modal -->
     <div class="search-modal-backdrop" id="search-modal-backdrop"></div>
     <div class="search-modal" id="search-modal">

--- a/script.js
+++ b/script.js
@@ -800,6 +800,15 @@ const searchResultsEmpty = document.getElementById('search-results-empty');
 let searchResults = [];
 let selectedResultIndex = -1;
 
+// Search icon button click handler
+const searchIconButton = document.getElementById('search-icon-button');
+if (searchIconButton) {
+  searchIconButton.addEventListener('click', function(e) {
+    e.preventDefault();
+    openSearchModal();
+  });
+}
+
 // Open search modal with CMD+K or Ctrl+K
 document.addEventListener('keydown', function(e) {
   // CMD+K (Mac) or Ctrl+K (Windows/Linux)

--- a/styles.css
+++ b/styles.css
@@ -1659,3 +1659,54 @@ body {
     max-height: calc(85vh - 200px);
   }
 }
+
+/* Search Icon Button - Fixed Bottom Right */
+.search-icon-button {
+  position: fixed;
+  bottom: var(--space-medium);
+  right: var(--space-medium);
+  width: 48px;
+  height: 48px;
+  background-color: var(--color-lello);
+  border: 1px solid var(--color-void-black);
+  border-radius: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 300;
+  transition: all var(--transition-normal);
+  box-shadow: var(--shadow-medium);
+}
+
+.search-icon-button:hover {
+  background-color: var(--color-lello-light);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lello-glow);
+}
+
+.search-icon-button:active {
+  background-color: #d4e600;
+  transform: translateY(0);
+  box-shadow: 0 2px 4px rgba(240, 255, 0, 0.2);
+}
+
+.search-icon-button i {
+  font-size: 20px;
+  color: var(--color-void-black);
+  pointer-events: none;
+}
+
+/* Responsive styles for search icon button */
+@media (max-width: 768px) {
+  .search-icon-button {
+    width: 44px;
+    height: 44px;
+    bottom: var(--space-small);
+    right: var(--space-small);
+  }
+
+  .search-icon-button i {
+    font-size: 18px;
+  }
+}


### PR DESCRIPTION
Add a fixed search icon button in the bottom-right corner that opens the existing search modal.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcf7758b-c560-4abe-936a-9289c194951d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fcf7758b-c560-4abe-936a-9289c194951d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

